### PR TITLE
Create ResultSet classes and LiveFlag role

### DIFF
--- a/AdServer/lib/AdServer/Role/LiveFlag.pm
+++ b/AdServer/lib/AdServer/Role/LiveFlag.pm
@@ -1,0 +1,5 @@
+package AdServer::Role::LiveFlag;
+
+use Moose::Role;
+
+1;

--- a/AdServer/lib/AdServer/Schema/ResultSet/Ad.pm
+++ b/AdServer/lib/AdServer/Schema/ResultSet/Ad.pm
@@ -1,0 +1,11 @@
+package AdServer::Schema::ResultSet::Ad;
+
+use Moose;
+use MooseX::NonMoose;
+extends 'DBIx::Class::ResultSet';
+
+with 'AdServer::Role::LiveFlag';
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/AdServer/lib/AdServer/Schema/ResultSet/Campaign.pm
+++ b/AdServer/lib/AdServer/Schema/ResultSet/Campaign.pm
@@ -1,0 +1,11 @@
+package AdServer::Schema::ResultSet::Campaign;
+
+use Moose;
+use MooseX::NonMoose;
+extends 'DBIx::Class::ResultSet';
+
+with 'AdServer::Role::LiveFlag';
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/AdServer/lib/AdServer/Schema/ResultSet/Client.pm
+++ b/AdServer/lib/AdServer/Schema/ResultSet/Client.pm
@@ -1,0 +1,11 @@
+package AdServer::Schema::ResultSet::Client;
+
+use Moose;
+use MooseX::NonMoose;
+extends 'DBIx::Class::ResultSet';
+
+with 'AdServer::Role::LiveFlag';
+
+__PACKAGE__->meta->make_immutable;
+
+1;


### PR DESCRIPTION
Fixes #7

Add ResultSet classes and LiveFlag role

* Create a Moose role named `AdServer::Role::LiveFlag` in `AdServer/lib/AdServer/Role/LiveFlag.pm`.
* Create ResultSet classes for Client, Campaign, and Ad in `AdServer/lib/AdServer/Schema/ResultSet/Client.pm`, `AdServer/lib/AdServer/Schema/ResultSet/Campaign.pm`, and `AdServer/lib/AdServer/Schema/ResultSet/Ad.pm` respectively.
* Inherit the new ResultSet classes from `DBIx::Class::ResultSet` using `MooseX::NonMoose`.
* Use the `AdServer::Role::LiveFlag` role in the new ResultSet classes.
* Make the new ResultSet classes immutable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/adserver/pull/8?shareId=233a9de6-59ea-4003-a8f6-4f73a1fda2d9).