### PR TITLE
Add search_live and find_live methods to role class

### DIFF
--- a/AdServer/lib/AdServer/Role/LiveFlag.pm
+++ b/AdServer/lib/AdServer/Role/LiveFlag.pm
@@ -2,4 +2,18 @@ package AdServer::Role::LiveFlag;
 
 use Moose::Role;
 
+sub search_live {
+    my ($self, $search, $attrs) = @_;
+    $search //= {};
+    $search->{is_live} = 1;
+    return $self->search($search, $attrs);
+}
+
+sub find_live {
+    my ($self, $search, $attrs) = @_;
+    $search //= {};
+    $search->{is_live} = 1;
+    return $self->find($search, $attrs);
+}
+
 1;


### PR DESCRIPTION
Fixes #6

Add `search_live` and `find_live` methods to `LiveFlag` role

* Add `search_live` method that overrides `is_live` key in `$search` to true and passes the call to the original `search` method.
* Add `find_live` method that overrides `is_live` key in `$search` to true and passes the call to the original `find` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/adserver/pull/9?shareId=5c872835-4926-4443-a921-08ae28c3f55d).