### PR TITLE
Change all calls to search() and find() in the Model class to use search_live() or find_live() as appropriate

### DIFF
--- a/AdServer/lib/AdServer/Model.pm
+++ b/AdServer/lib/AdServer/Model.pm
@@ -17,14 +17,14 @@ sub get_client_from_code {
   my ($client_code, $get_campaigns) = @_;
 
   if ($get_campaigns) {
-    return $self->schema->resultset('Client')->find({
+    return $self->schema->resultset('Client')->find_live({
       code => $client_code,
     }, {
       prefetch => 'campaigns',
     });
   }
 
-  return $self->schema->resultset('Client')->find({
+  return $self->schema->resultset('Client')->find_live({
     code => $client_code,
   });
 }
@@ -35,14 +35,14 @@ sub get_client_campaign_from_code {
 
   return unless $client;
   if ($get_ads) {
-    return $client->campaigns->find({
+    return $client->campaigns->find_live({
       code => $campaign_code,
     }, {
       prefetch => 'ads',
     });
   }
 
-  return $client->campaigns->find({
+  return $client->campaigns->find_live({
     code => $campaign_code,
   });
 }
@@ -52,7 +52,7 @@ sub get_ad_from_code {
   my ($campaign, $ad_code) = @_;
 
   return unless $campaign;
-  return $campaign->ads->find({
+  return $campaign->ads->find_live({
     code => $ad_code,
   });
 }
@@ -61,13 +61,13 @@ sub get_ad_from_hash {
   my $self = shift;
   my ($ad_hash) = @_;
 
-  return $self->schema->resultset('Ad')->find({ hash => $ad_hash});
+  return $self->schema->resultset('Ad')->find_live({ hash => $ad_hash});
 }
 
 sub get_clients {
   my $self = shift;
 
-  return map { { $_->get_columns } } $self->schema->resultset('Client')->all;
+  return map { { $_->get_columns } } $self->schema->resultset('Client')->search_live;
 }
 
 1;


### PR DESCRIPTION
Fixes #10

Update `AdServer/lib/AdServer/Model.pm` to use `search_live()` and `find_live()` methods.

* Change `get_client_from_code` method to use `find_live()` instead of `find()`.
* Change `get_client_campaign_from_code` method to use `find_live()` instead of `find()`.
* Change `get_ad_from_code` method to use `find_live()` instead of `find()`.
* Change `get_ad_from_hash` method to use `find_live()` instead of `find()`.
* Change `get_clients` method to use `search_live()` instead of `search()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/adserver/pull/11?shareId=51227cdb-bdad-433d-8528-4209dafd4556).